### PR TITLE
Refactor shader handlers

### DIFF
--- a/Assets/Scenes/Script/ComputeShaderHandler.cs
+++ b/Assets/Scenes/Script/ComputeShaderHandler.cs
@@ -1,43 +1,9 @@
 using UnityEngine;
 
-public class ComputeShaderHandler : MonoBehaviour
+public class ComputeShaderHandler : MonoBehaviour, IShaderHandler
 {
-    [SerializeField] ComputeShader _mainComputeShader = null;
-    [SerializeField, Range(0, 2)] float _saturation = 1.0f;
-    [SerializeField, Range(0, 2)] float _contrast = 1.0f;
-    [SerializeField, Range(1, 64)] int _mosaicSize = 1;
-    [SerializeField, Range(1, 256)] int _colorLevel = 256;
-    
-    private struct ThreadSize
+    public virtual void RunShader(RenderTexture inputTexture, RenderTexture tempTexture, RenderTexture outputTexture)
     {
-        public uint x;
-        public uint y;
-        public uint z;
-
-        public ThreadSize(uint x, uint y, uint z)
-        {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-        }
-    }
-    private ThreadSize _threadSize;
-
-    public void RunComputeShader(RenderTexture inputTexture, RenderTexture tempTexture, RenderTexture outputTexture)
-    {
-        // 一つのグループの中に何個のスレッドがあるか
-        var kernelIndex = _mainComputeShader.FindKernel("PixelArt");
-        _mainComputeShader.GetKernelThreadGroupSizes(kernelIndex, out _threadSize.x, out _threadSize.y, out _threadSize.z);
-
-        // パラメーターを設定してコンピュートシェーダーを実行
-        _mainComputeShader.SetTexture(kernelIndex, "inputTexture", inputTexture);
-        _mainComputeShader.SetTexture(kernelIndex, "tempTexture", tempTexture);
-        _mainComputeShader.SetTexture(kernelIndex, "outputTexture", outputTexture);
-        _mainComputeShader.SetInt("mosaicSize", _mosaicSize);
-        _mainComputeShader.SetInt("colorLevel", _colorLevel);
-        _mainComputeShader.SetInts("dimensions", new int[] { inputTexture.width, inputTexture.height });
-        _mainComputeShader.SetFloat("saturation", _saturation);
-        _mainComputeShader.SetFloat("contrast", _contrast);
-        _mainComputeShader.Dispatch(kernelIndex, inputTexture.width / (int)_threadSize.x, inputTexture.height / (int)_threadSize.y, (int)_threadSize.z);
+        // Override in subclasses
     }
 }

--- a/Assets/Scenes/Script/IShaderHandler.cs
+++ b/Assets/Scenes/Script/IShaderHandler.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+
+public interface IShaderHandler
+{
+    void RunShader(RenderTexture inputTexture, RenderTexture tempTexture, RenderTexture outputTexture);
+}

--- a/Assets/Scenes/Script/IShaderHandler.cs.meta
+++ b/Assets/Scenes/Script/IShaderHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0c6286e610f382942b21c0902df751fd
+guid: 3fc2bd51ef843d945848c79793cc66bf
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scenes/Script/PixelArtHandler.cs
+++ b/Assets/Scenes/Script/PixelArtHandler.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class PixelArtHandler : ComputeShaderHandler
+{
+    [SerializeField] ComputeShader _mainComputeShader = null;
+    [SerializeField, Range(0, 2)] float _saturation = 1.0f;
+    [SerializeField, Range(0, 2)] float _contrast = 1.0f;
+    [SerializeField, Range(1, 64)] int _mosaicSize = 1;
+    [SerializeField, Range(1, 256)] int _colorLevel = 256;
+    
+    private struct ThreadSize
+    {
+        public uint x;
+        public uint y;
+        public uint z;
+
+        public ThreadSize(uint x, uint y, uint z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+    }
+    private ThreadSize _threadSize;
+    
+    public override void RunShader(RenderTexture inputTexture, RenderTexture tempTexture, RenderTexture outputTexture)
+    {
+        // 一つのグループの中に何個のスレッドがあるか
+        var kernelIndex = _mainComputeShader.FindKernel("PixelArt");
+        _mainComputeShader.GetKernelThreadGroupSizes(kernelIndex, out _threadSize.x, out _threadSize.y, out _threadSize.z);
+
+        // パラメーターを設定してコンピュートシェーダーを実行
+        _mainComputeShader.SetTexture(kernelIndex, "inputTexture", inputTexture);
+        _mainComputeShader.SetTexture(kernelIndex, "tempTexture", tempTexture);
+        _mainComputeShader.SetTexture(kernelIndex, "outputTexture", outputTexture);
+        _mainComputeShader.SetInt("mosaicSize", _mosaicSize);
+        _mainComputeShader.SetInt("colorLevel", _colorLevel);
+        _mainComputeShader.SetInts("dimensions", new int[] { inputTexture.width, inputTexture.height });
+        _mainComputeShader.SetFloat("saturation", _saturation);
+        _mainComputeShader.SetFloat("contrast", _contrast);
+
+        _mainComputeShader.Dispatch(kernelIndex, inputTexture.width / (int)_threadSize.x, inputTexture.height / (int)_threadSize.y, (int)_threadSize.z);
+    }
+}

--- a/Assets/Scenes/Script/PixelArtHandler.cs.meta
+++ b/Assets/Scenes/Script/PixelArtHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0c6286e610f382942b21c0902df751fd
+guid: 484cdea96401f3743990788fa1a73cde
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scenes/Script/Visualizer.cs
+++ b/Assets/Scenes/Script/Visualizer.cs
@@ -4,35 +4,43 @@ using Klak.TestTools;
 
 sealed class Visualizer : MonoBehaviour
 {
-    [SerializeField] ImageSource _source = null;
-    [SerializeField] RawImage _preview = null;
-    [SerializeField] ComputeShaderHandler _shaderHandler = null;
+    [SerializeField] private ImageSource _source = null;
+    [SerializeField] private RawImage _preview = null;
+    [SerializeField] private ComputeShaderHandler _shaderHandler = null;
 
-    public RenderTexture _sourceTexture;
+    private RenderTexture _sourceTexture;
     private RenderTexture _previewTexture;
     private RenderTexture _tempTexture;
 
-    void Start()
+    private void Start()
+    {
+        InitializeTextures();
+    }
+
+    private void Update()
+    {
+        RunImageProcessing();
+    }
+
+    private void InitializeTextures()
     {
         _sourceTexture = _source.Texture as RenderTexture;
-
-        _previewTexture = new RenderTexture(_sourceTexture.width, _sourceTexture.height, 0);
-        _previewTexture.enableRandomWrite = true;
-        _previewTexture.Create();
-
-        _tempTexture = new RenderTexture(_sourceTexture.width, _sourceTexture.height, 0);
-        _tempTexture.enableRandomWrite = true;
-        _tempTexture.Create();
+        _previewTexture = CreateRenderTexture(_sourceTexture.width, _sourceTexture.height);
+        _tempTexture = CreateRenderTexture(_sourceTexture.width, _sourceTexture.height);
     }
 
-    void Update()
+    private RenderTexture CreateRenderTexture(int width, int height)
     {
-        ImageProcessing();
+        var renderTexture = new RenderTexture(width, height, 0);
+        renderTexture.enableRandomWrite = true;
+        renderTexture.Create();
+
+        return renderTexture;
     }
 
-    private void ImageProcessing()
+    private void RunImageProcessing()
     {        
-        _shaderHandler.RunComputeShader(_sourceTexture, _tempTexture, _previewTexture);
+        _shaderHandler.RunShader(_sourceTexture, _tempTexture, _previewTexture);
         _preview.texture = _previewTexture;
     }
 }

--- a/Assets/Scenes/Shader/PixelArt.compute
+++ b/Assets/Scenes/Shader/PixelArt.compute
@@ -2,7 +2,6 @@
 #include "Contrast.hlsl"
 #include "Mosaic.hlsl"
 #include "Quantize.hlsl"
-#include "EdgeDetection.hlsl"
 #include "Linear2Gamma.hlsl"
 
 #pragma kernel PixelArt
@@ -10,9 +9,11 @@
 RWTexture2D<float4> outputTexture;
 Texture2D<float4> inputTexture;
 RWTexture2D<float4> tempTexture;
+
 int mosaicSize;
 int colorLevel;
 int2 dimensions;
+
 float saturation;
 float contrast;
 
@@ -23,14 +24,12 @@ void PixelArt (uint3 id : SV_DispatchThreadID)
     float4 tempColor = tempTexture[id.xy];
 
     ChangeSaturation(tempColor, saturation, tempColor);
-
     Contrast(tempColor, contrast, tempColor);
+
     tempTexture[id.xy] = tempColor;
     
     Mosaic(tempTexture, id, mosaicSize, dimensions, tempColor);
-
     Quantize(tempColor, colorLevel, tempColor);
-    
     Linear2Gamma(tempColor, tempColor);
     
     outputTexture[id.xy] = tempColor;

--- a/Assets/Scenes/Visualizer.unity
+++ b/Assets/Scenes/Visualizer.unity
@@ -132,8 +132,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 367290630}
-  - component: {fileID: 367290629}
   - component: {fileID: 367290631}
+  - component: {fileID: 367290633}
   - component: {fileID: 367290632}
   m_Layer: 0
   m_Name: Visualizer
@@ -142,22 +142,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &367290629
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 367290628}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b0fc311bcf7a4d44d8007f2306dfb2b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _source: {fileID: 367290631}
-  _preview: {fileID: 2053451812}
-  _shaderHandler: {fileID: 367290632}
-  _sourceTexture: {fileID: 0}
 --- !u!4 &367290630
 Transform:
   m_ObjectHideFlags: 0
@@ -214,6 +198,21 @@ MonoBehaviour:
   _contrast: 1
   _mosaicSize: 1
   _colorLevel: 256
+--- !u!114 &367290633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 367290628}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0fc311bcf7a4d44d8007f2306dfb2b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _source: {fileID: 367290631}
+  _preview: {fileID: 2053451812}
+  _shaderHandler: {fileID: 367290632}
 --- !u!1 &616222626
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Refactor shader handlers

- Create new interface IShaderHandler to generalize shader handling
- Create new PixelArtHandler class implementing IShaderHandler for specific pixel art processing
- Refactor Visualizer to use new IShaderHandler interface, allowing assignment of specific handlers in Unity inspector
- Rename and repurpose ComputeShaderHandler from previous PixelArtHandler to serve as a base class for shader handlers